### PR TITLE
feat(amneziawg): add network policy

### DIFF
--- a/charts/amneziawg/Chart.yaml
+++ b/charts/amneziawg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: amneziawg
 description: A Helm chart for managing a amnezia-wg vpn in kubernetes
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.0.0"
 maintainers:
   - name: mikolajsobolewski

--- a/charts/amneziawg/templates/networkpolicy.yaml
+++ b/charts/amneziawg/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.networkPolicy.enabled .Values.service.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "{{ .Release.Name }}-wireguard"
+  labels:
+    app: "{{ .Release.Name }}-wireguard"
+spec:
+  podSelector:
+    matchLabels:
+      app: "{{ .Release.Name }}-wireguard"
+  ingress:
+    - ports:
+        - protocol: UDP
+          port: {{ .Values.service.port }}
+        {{- if .Values.healthSideCar.enabled }}
+        - protocol: TCP
+          port: {{ .Values.healthSideCar.service.port }}
+        {{- end }}
+  policyTypes:
+    - Ingress
+{{- end }}

--- a/charts/amneziawg/values.yaml
+++ b/charts/amneziawg/values.yaml
@@ -103,6 +103,8 @@ service:
   annotations: {}
   # -- Extra ports that can be attached to the service object, these are passed directly to the port array on the service and must be well formed to the specification
   extraPorts: []
+networkPolicy:
+  enabled: false
 # -- Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one.
 secretName: ~
 replicaCount: 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Helm chart version to 0.2.0.
	- Introduced a new Kubernetes NetworkPolicy resource to manage incoming traffic based on specified conditions.
  
- **Configuration Changes**
	- Added a `networkPolicy` section in the configuration, with network policies disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->