### PR TITLE
feat(eq-backend): add network policy

### DIFF
--- a/charts/eq-backend/Chart.yaml
+++ b/charts/eq-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: eq-backend
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
+version: 0.2.0
 maintainers:
   - name: "mikolajsobolewski"
 appVersion: "latest"

--- a/charts/eq-backend/templates/networkpolicy.yaml
+++ b/charts/eq-backend/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "eq-backend.fullname" . }}
+  labels:
+    {{- include "eq-backend.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "eq-backend.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+  policyTypes:
+    - Ingress
+{{- end }}

--- a/charts/eq-backend/values.yaml
+++ b/charts/eq-backend/values.yaml
@@ -56,6 +56,9 @@ secretManager:
     annotations: {}
   spec: {}
 
+networkPolicy:
+  enabled: true
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Kubernetes NetworkPolicy to manage incoming traffic based on specific labels.
	- Added a configuration option to enable network policies in the deployment settings.

- **Version Update**
	- Updated the version of the `eq-backend` Helm chart from 0.1.2 to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->