### PR TITLE
feat: custom service for path

### DIFF
--- a/charts/main/Chart.yaml
+++ b/charts/main/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: main
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.2
+version: 0.6.3
 maintainers:
   - name: "zavertiaev"
   - name: "mikolajsobolewski"

--- a/charts/main/README.md
+++ b/charts/main/README.md
@@ -31,10 +31,10 @@ A Helm chart for Kubernetes
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `""` |  |
+| ingress.hosts[0].paths[0].name | string | `""` | Custom serviceName |
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
-| ingress.hosts[0].paths[0].port | string | `nil` | Custom port |
-| ingress.hosts[0].paths[0].serviceName | string | `""` | Custom serviceName |
+| ingress.hosts[0].paths[0].port | string | `""` | Custom servicePort |
 | ingress.tls | list | `[]` |  |
 | livenessProbe.enabled | bool | `false` |  |
 | livenessProbe.failureThreshold | int | `5` |  |

--- a/charts/main/README.md
+++ b/charts/main/README.md
@@ -1,6 +1,6 @@
 # main
 
-![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/main/README.md
+++ b/charts/main/README.md
@@ -33,6 +33,8 @@ A Helm chart for Kubernetes
 | ingress.hosts[0].host | string | `""` |  |
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.hosts[0].paths[0].port | string | `nil` | Custom port |
+| ingress.hosts[0].paths[0].serviceName | string | `""` | Custom serviceName |
 | ingress.tls | list | `[]` |  |
 | livenessProbe.enabled | bool | `false` |  |
 | livenessProbe.failureThreshold | int | `5` |  |

--- a/charts/main/templates/ingress.yaml
+++ b/charts/main/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
             pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
-                name: {{ .serviceName | default (include "main.fullname" $) }}
+                name: {{ .name | default (include "main.fullname" $) }}
                 port:
                   number: {{ .port }}
           {{- end }}

--- a/charts/main/templates/ingress.yaml
+++ b/charts/main/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
             pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
-                name: {{ include "main.fullname" $ }}
+                name: {{ .serviceName | default (include "main.fullname" $) }}
                 port:
                   number: {{ .port }}
           {{- end }}

--- a/charts/main/values.yaml
+++ b/charts/main/values.yaml
@@ -53,6 +53,10 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
+# -- Custom serviceName
+          serviceName: ""
+# -- Custom port
+          port:
   tls: []
 
 probe:

--- a/charts/main/values.yaml
+++ b/charts/main/values.yaml
@@ -54,9 +54,9 @@ ingress:
         - path: /
           pathType: ImplementationSpecific
 # -- Custom serviceName
-          serviceName: ""
-# -- Custom port
-          port:
+          name: ""
+# -- Custom servicePort
+          port: ""
   tls: []
 
 probe:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom service name and port in ingress rules for more flexible backend configuration.

* **Documentation**
  * Updated the version badge in the Helm chart README to reflect the new version.
  * Documented new ingress configuration options for custom service name and port.

* **Chores**
  * Bumped the Helm chart version from 0.6.2 to 0.6.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->