### PR TITLE
feat(amneziawg): support AmneziaWG 2.0 obfuscation params

### DIFF
--- a/charts/amneziawg/Chart.yaml
+++ b/charts/amneziawg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: amneziawg
 description: A Helm chart for managing a amnezia-wg vpn in kubernetes
 type: application
-version: 0.2.2
-appVersion: "0.0.0"
+version: 0.3.0
+appVersion: "3.0.2"
 maintainers:
   - name: mikolajsobolewski

--- a/charts/amneziawg/README.md
+++ b/charts/amneziawg/README.md
@@ -57,9 +57,9 @@ A Helm chart for managing a amnezia-wg vpn in kubernetes
 | healthSideCar.service.type | string | `"NodePort"` | Service type, given the use case, in most cases this should be NodePort |
 | healthSideCar.useHostPort | bool | `false` | When enabled the container will define a host port, in most cases this should only be used when deploying with daemonSet: true |
 | hostPort | int | `51820` | Host port to expose the VPN service on |
-| image.pullPolicy | string | `"Always"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/mikolajsobolewski/awg"` |  |
-| image.tag | string | `"main"` | Rolling tag built by the oci-amneziawg CI from its default branch (`main`). Carries AmneziaWG 2.0 (amneziawg-go 3.0.2). |
+| image.tag | string | `"3.0.2"` | Immutable image tag matching appVersion (amneziawg-go / AmneziaWG 2.0). Published by oci-amneziawg CI from the `v3.0.2` git tag. |
 | keygenJob.command | list | `["/job/entry-point.sh"]` | Specify the script to run to generate the private key |
 | keygenJob.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | keygenJob.containerSecurityContext.privileged | bool | `false` |  |

--- a/charts/amneziawg/README.md
+++ b/charts/amneziawg/README.md
@@ -1,6 +1,6 @@
 # amneziawg
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.2](https://img.shields.io/badge/AppVersion-3.0.2-informational?style=flat-square)
 
 A Helm chart for managing a amnezia-wg vpn in kubernetes
 
@@ -24,6 +24,8 @@ A Helm chart for managing a amnezia-wg vpn in kubernetes
 | amneziawg.jmin | string | `"50"` | jmin < jmax; recommended value is 50 |
 | amneziawg.s1 | string | `"105"` | s1 — s1 < 1280; s1 + 56 ≠ s2; recommended range is from 15 to 150 inclusive |
 | amneziawg.s2 | string | `"61"` |  |
+| amneziawg.s3 | string | `""` | AmneziaWG 2.0 second packet-size pair. Opt-in: leave empty to keep the 1.x wire format. When set, every peer must set S3/S4 to the same values. Recommended 15–150; s3 + 56 ≠ s4 and s4 + 56 ≠ s3 |
+| amneziawg.s4 | string | `""` | AmneziaWG 2.0 second packet-size pair; see s3 |
 | autoscaling.enabled | bool | `true` |  |
 | autoscaling.maxReplicas | int | `10` |  |
 | autoscaling.minReplicas | int | `3` |  |
@@ -57,7 +59,7 @@ A Helm chart for managing a amnezia-wg vpn in kubernetes
 | hostPort | int | `51820` | Host port to expose the VPN service on |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/mikolajsobolewski/awg"` |  |
-| image.tag | string | `"master"` |  |
+| image.tag | string | `"main"` | Rolling tag built by the oci-amneziawg CI from its default branch (`main`). Carries AmneziaWG 2.0 (amneziawg-go 3.0.2). |
 | keygenJob.command | list | `["/job/entry-point.sh"]` | Specify the script to run to generate the private key |
 | keygenJob.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | keygenJob.containerSecurityContext.privileged | bool | `false` |  |

--- a/charts/amneziawg/templates/config.yaml
+++ b/charts/amneziawg/templates/config.yaml
@@ -14,6 +14,12 @@ Jmin = {{ .Values.amneziawg.jmin }}
 Jmax = {{ .Values.amneziawg.jmax }}
 S1 = {{ .Values.amneziawg.s1 }}
 S2 = {{ .Values.amneziawg.s2 }}
+{{- if .Values.amneziawg.s3 }}
+S3 = {{ .Values.amneziawg.s3 }}
+{{- end }}
+{{- if .Values.amneziawg.s4 }}
+S4 = {{ .Values.amneziawg.s4 }}
+{{- end }}
 H1 = {{ .Values.amneziawg.h1 }}
 H2 = {{ .Values.amneziawg.h2  }}
 H3 = {{ .Values.amneziawg.h3 }}

--- a/charts/amneziawg/values.yaml
+++ b/charts/amneziawg/values.yaml
@@ -2,9 +2,9 @@
 daemonSet: false
 image:
   repository: ghcr.io/mikolajsobolewski/awg
-  # -- Rolling tag built by the oci-amneziawg CI from its default branch (`main`). Carries AmneziaWG 2.0 (amneziawg-go 3.0.2).
-  tag: main
-  pullPolicy: Always
+  # -- Immutable image tag matching appVersion (amneziawg-go / AmneziaWG 2.0). Published by oci-amneziawg CI from the `v3.0.2` git tag.
+  tag: "3.0.2"
+  pullPolicy: IfNotPresent
 
 keygenJob:
   # -- when enabled, uses a image with go bindings for k8s and wg

--- a/charts/amneziawg/values.yaml
+++ b/charts/amneziawg/values.yaml
@@ -2,7 +2,8 @@
 daemonSet: false
 image:
   repository: ghcr.io/mikolajsobolewski/awg
-  tag: master
+  # -- Rolling tag built by the oci-amneziawg CI from its default branch (`main`). Carries AmneziaWG 2.0 (amneziawg-go 3.0.2).
+  tag: main
   pullPolicy: Always
 
 keygenJob:
@@ -56,7 +57,11 @@ amneziawg:
   s1: "105"
   #-- s2 — s2 < 1280; recommended range is from 15 to 150 inclusive
   s2: "61"
-  #-- h1/h2/h3/h4 — must be unique among each other; recommended range is from 5 to 2147483647 inclusive
+  # -- AmneziaWG 2.0 second packet-size pair. Opt-in: leave empty to keep the 1.x wire format. When set, every peer must set S3/S4 to the same values. Recommended 15–150; s3 + 56 ≠ s4 and s4 + 56 ≠ s3
+  s3: ""
+  # -- AmneziaWG 2.0 second packet-size pair; see s3
+  s4: ""
+  #-- h1/h2/h3/h4 — must be unique among each other; recommended range is from 5 to 2147483647 inclusive. AmneziaWG 2.0 also accepts non-overlapping ranges "min-max" (e.g. "5-100000004"); all peers must match
   h1: "986154639"
   h2: "1947194286"
   h3: "929919087"


### PR DESCRIPTION
## What

Teach the `amneziawg` chart the **AmneziaWG 2.0** obfuscation params and pin it to the 2.0-capable image.

- `values.amneziawg.s3` / `s4` — new second packet-size pair (empty default)
- `H1`–`H4` now also accept ranged `min-max` values (no template change — they pass through as strings)
- `image.tag`: `master` → **`"3.0.2"`** (immutable semver, matches `appVersion`); `pullPolicy` → `IfNotPresent`
- chart `0.2.2` → `0.3.0`, `appVersion` → `3.0.2`

## Backward compatible by design

S3/S4 are **opt-in**. The config template renders them only when set:

```gotemplate
{{- if .Values.amneziawg.s3 }}
S3 = {{ .Values.amneziawg.s3 }}
{{- end }}
```

Upgrading an existing release with no `s3`/`s4` set produces an **unchanged** `wg0.conf` — existing peers keep working. Enabling 2.0 is a deliberate, coordinated step (server **and** all clients must set matching S3/S4).

## Image pin

`image.tag` moves from the rolling `master` branch tag to the immutable `3.0.2` semver published by the oci-amneziawg CI, so the deployed version is reproducible and roll-back-able, and lines up with `appVersion: 3.0.2`.

## Verification

- `helm lint` ✅, `helm template` ✅ (default and 2.0 modes)
- Rendered config in both modes run through `amneziawg-go:3.0.2` in userspace mode (the k8s path) — interface up cleanly, no 3.0-only features engaged.

## Depends on / order

1. Merge mikolajsobolewski/oci-amneziawg#1 (base bump + semver CI).
2. Push git tag `v3.0.2` there → publishes `ghcr.io/mikolajsobolewski/awg:3.0.2`.
3. Merge this PR.