### PR TITLE
feat(amneziawg): optional AmneziaWG 3 header protection

### DIFF
--- a/charts/amneziawg/Chart.yaml
+++ b/charts/amneziawg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: amneziawg
 description: A Helm chart for managing a amnezia-wg vpn in kubernetes
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "3.0.2"
 maintainers:
   - name: mikolajsobolewski

--- a/charts/amneziawg/README.md
+++ b/charts/amneziawg/README.md
@@ -1,6 +1,6 @@
 # amneziawg
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.2](https://img.shields.io/badge/AppVersion-3.0.2-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.2](https://img.shields.io/badge/AppVersion-3.0.2-informational?style=flat-square)
 
 A Helm chart for managing a amnezia-wg vpn in kubernetes
 
@@ -19,6 +19,9 @@ A Helm chart for managing a amnezia-wg vpn in kubernetes
 | amneziawg.h2 | string | `"1947194286"` |  |
 | amneziawg.h3 | string | `"929919087"` |  |
 | amneziawg.h4 | string | `"1621034805"` |  |
+| amneziawg.headerProtection.enabled | bool | `false` | Enable AmneziaWG 3 header protection (see warning above). Only turn on when the whole client fleet supports and sets the same key. |
+| amneziawg.headerProtection.existingSecret | string | `""` | Name of an existing Secret holding the key (hex) under key `header-protection.key`. Overrides `key` when set. |
+| amneziawg.headerProtection.key | string | `""` | 32-byte key as 64 hex chars, e.g. `openssl rand -hex 32` (NOT base64 / `awg genkey`). Must be identical on every client. Stored in a Secret. Required when enabled unless existingSecret is set. |
 | amneziawg.jc | string | `"6"` | 1 ≤ jc ≤ 128; recommended range is from 3 to 10 inclusive |
 | amneziawg.jmax | string | `"1000"` | jmin < jmax ≤ 1280; recommended value is 1000 |
 | amneziawg.jmin | string | `"50"` | jmin < jmax; recommended value is 50 |
@@ -59,7 +62,7 @@ A Helm chart for managing a amnezia-wg vpn in kubernetes
 | hostPort | int | `51820` | Host port to expose the VPN service on |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/mikolajsobolewski/awg"` |  |
-| image.tag | string | `"3.0.2"` | Immutable image tag matching appVersion (amneziawg-go / AmneziaWG 2.0). Published by oci-amneziawg CI from the `v3.0.2` git tag. |
+| image.tag | string | `"3.0.2-1"` | Immutable image tag (amneziawg-go 3.0.2, image rev 1 adds optional header protection). Published by oci-amneziawg CI from the `v3.0.2-1` git tag. Backward compatible with `3.0.2`. |
 | keygenJob.command | list | `["/job/entry-point.sh"]` | Specify the script to run to generate the private key |
 | keygenJob.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | keygenJob.containerSecurityContext.privileged | bool | `false` |  |

--- a/charts/amneziawg/templates/deployment.yaml
+++ b/charts/amneziawg/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
         {{- if not .Values.configSecretName }}
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         {{- end }}
+        {{- if and .Values.amneziawg.headerProtection.enabled (not .Values.amneziawg.headerProtection.existingSecret) }}
+        checksum/header-protection: {{ include (print $.Template.BasePath "/header-protection-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- range $key, $value := .Values.podAnnotations  }}
         {{ $key }}: {{ $value | quote }}
@@ -192,6 +195,12 @@ spec:
             mountPath: /etc/wireguard/privatekey
             subPath: privatekey
           {{- end }}
+          {{- if .Values.amneziawg.headerProtection.enabled }}
+          - name: headerprotection
+            mountPath: /etc/amneziawg/header-protection.key
+            subPath: header-protection.key
+            readOnly: true
+          {{- end }}
           {{- if .Values.volumeMounts }}
             {{- .Values.volumeMounts | toYaml | nindent 10 }}
           {{- end }}
@@ -283,6 +292,14 @@ spec:
       - name: privatekey
         secret:
           secretName: "{{ coalesce .Values.secretName (printf "%s-wg-generated" .Release.Name) }}"
+      {{- end }}
+      {{- if .Values.amneziawg.headerProtection.enabled }}
+      - name: headerprotection
+        secret:
+          secretName: "{{ coalesce .Values.amneziawg.headerProtection.existingSecret (printf "%s-wg-header-protection" .Release.Name) }}"
+          items:
+            - key: header-protection.key
+              path: header-protection.key
       {{- end }}
       {{- if .Values.volumes }}
         {{- .Values.volumes | toYaml | nindent 6 }}

--- a/charts/amneziawg/templates/header-protection-secret.yaml
+++ b/charts/amneziawg/templates/header-protection-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.amneziawg.headerProtection.enabled }}
+{{- if not .Values.amneziawg.headerProtection.existingSecret }}
+{{- $key := .Values.amneziawg.headerProtection.key | default "" }}
+{{- if not $key }}
+{{- fail "amneziawg.headerProtection.enabled=true requires either amneziawg.headerProtection.key or amneziawg.headerProtection.existingSecret" }}
+{{- end }}
+{{- if not (regexMatch "^[0-9a-fA-F]{64}$" $key) }}
+{{- fail "amneziawg.headerProtection.key must be a 32-byte key as 64 hex chars (e.g. `openssl rand -hex 32`), not base64" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-wg-header-protection"
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  header-protection.key: {{ $key | quote }}
+{{- end }}
+{{- end }}

--- a/charts/amneziawg/values.yaml
+++ b/charts/amneziawg/values.yaml
@@ -2,8 +2,8 @@
 daemonSet: false
 image:
   repository: ghcr.io/mikolajsobolewski/awg
-  # -- Immutable image tag matching appVersion (amneziawg-go / AmneziaWG 2.0). Published by oci-amneziawg CI from the `v3.0.2` git tag.
-  tag: "3.0.2"
+  # -- Immutable image tag (amneziawg-go 3.0.2, image rev 1 adds optional header protection). Published by oci-amneziawg CI from the `v3.0.2-1` git tag. Backward compatible with `3.0.2`.
+  tag: "3.0.2-1"
   pullPolicy: IfNotPresent
 
 keygenJob:
@@ -66,6 +66,18 @@ amneziawg:
   h2: "1947194286"
   h3: "929919087"
   h4: "1621034805"
+  # AmneziaWG 3 header protection. WARNING: symmetric — the SAME key must be set on
+  # the server AND every client. Clients that cannot set it (notably amneziawg-apple /
+  # iOS/macOS) will fail to connect. Requires S1–S4 ≥ 8. The key is injected into the
+  # running device over the UAPI socket by the container entrypoint (the config parser
+  # cannot set it). Disabled by default.
+  headerProtection:
+    # -- Enable AmneziaWG 3 header protection (see warning above). Only turn on when the whole client fleet supports and sets the same key.
+    enabled: false
+    # -- 32-byte key as 64 hex chars, e.g. `openssl rand -hex 32` (NOT base64 / `awg genkey`). Must be identical on every client. Stored in a Secret. Required when enabled unless existingSecret is set.
+    key: ""
+    # -- Name of an existing Secret holding the key (hex) under key `header-protection.key`. Overrides `key` when set.
+    existingSecret: ""
 wireguard:
   # -- Address of the VPN server
   serverAddress: 10.34.0.1/24


### PR DESCRIPTION
Stacked on #29 (base: `feat/amneziawg-2.0`). Adds **opt-in, disabled-by-default** AmneziaWG 3 header protection.

## Why the entrypoint injects it
`amneziawg-tools` (all releases) cannot parse `HeaderProtectionKey` from `wg0.conf` — the `amneziawg-go` engine only accepts it over its UAPI socket. So the image (mikolajsobolewski/oci-amneziawg#2, tag `3.0.2-1`) injects the key post-bring-up; this chart just supplies the key as a mounted Secret at `/etc/amneziawg/header-protection.key`.

## Changes
- `values.amneziawg.headerProtection.{enabled,key,existingSecret}`
- new Secret template — **validates** the key is 64 hex chars (rejects base64 / `awg genkey`)
- deployment: conditional volume + mount + checksum annotation
- `image.tag` → `3.0.2-1` (backward-compatible superset of `3.0.2`)
- chart `0.3.0` → `0.4.0`

## ⚠️ Operational warning (documented in values/README)
Header protection is **symmetric — the same key must be set on the server AND every client**. Clients that can't set it — notably **amneziawg-apple (iOS/macOS)** — will **fail to connect**. `amnezia-client` GUI 5.x, Android and Windows support it. Enable only when the whole client fleet is ready. Requires `S1–S4 ≥ 8`.

## Verified
- Template renders: default → no HP objects; `enabled + hex key` → Secret + mount + volume; `existingSecret` → references it, no created Secret; `enabled` without key **fails**; base64 key **fails**. `helm lint` clean.
- Image entrypoint injection verified end-to-end on the built `3.0.2-1` image: `get=1` shows `header_protection_key=<same key>` when mounted; absent key → feature off.

## Merge order
Merge #29 first (this retargets to `main` automatically), then this. Image `ghcr.io/mikolajsobolewski/awg:3.0.2-1` is already published.